### PR TITLE
feat: starting prompt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,6 @@ Go to https://chat.openai.com/chat log in
 
 ### Have A Good Chat !
 
+## Optional: Setup starting prompt
+* A starting prompt would be invoked when the bot is first started or reset. All the text in the file will be fired as a prompt to the bot.  
+* You can set it up by adding a `starting-prompt.txt` file in the same directory as `config.json`.

--- a/src/bot.py
+++ b/src/bot.py
@@ -31,6 +31,23 @@ async def send_message(message, user_message):
         print(e)
 
 
+async def send_start_prompt() :
+    import os
+    import os.path
+
+    config_dir = os.path.abspath(__file__ + "/../../")
+    prompt_name = 'starting-prompt.txt'
+    prompt_path = os.path.join(config_dir, prompt_name)
+    if os.path.isfile(prompt_path):
+        with open(prompt_path, "r") as f:
+            prompt = f.read()
+            logger.info(f"Send starting prompt with size {len(prompt)}")
+            responseMessage = await responses.handle_response(prompt)
+        logger.info(f"Starting prompt response: {responseMessage}")
+    else:
+        logger.info(f"No {prompt_name}. Skip sending starting prompt.")
+
+
 def run_discord_bot():
     intents = discord.Intents.default()
     intents.message_content = True
@@ -39,6 +56,7 @@ def run_discord_bot():
 
     @client.event
     async def on_ready():
+        await send_start_prompt()
         await client.tree.sync()
         logger.info(f'{client.user} is now running!')
 
@@ -84,6 +102,7 @@ def run_discord_bot():
         await interaction.followup.send("> **Info: I have forgotten everything.**")
         logger.warning(
             "\x1b[31mChatGPT bot has been successfully reset\x1b[0m")
+        await send_start_prompt()
 
     TOKEN = data['discord_bot_token']
     client.run(TOKEN)


### PR DESCRIPTION
Cheers to the great project!

I'm adding a feature to enable sending prompts automatically at every session start:

> ## Optional: Setup starting prompt
> * A starting prompt would be invoked when the bot is first started or reset. All the text in the file will be fired as a prompt to the bot.  
> * You can set it up by adding a `starting-prompt.txt` file in the same directory as `config.json`.

For example, I have the file `starting-prompt.txt` with content 
```
I'm a cute robot.
```
Then it will fire the prompt to ChatGPT at start:
```log
2022-12-10 19:36:50 INFO     discord.client logging in using static token
2022-12-10 19:36:53 INFO     discord.gateway Shard ID None has connected to Gateway (Session ID: <masked>).
2022-12-10 19:36:56 INFO     src -> Send starting prompt with size 17
2022-12-10 19:37:05 INFO     src -> Starting prompt response: While it's possible for robots to be cute, it's not a given. Robots can come in many shapes, sizes, and appearances, and some may be more aesthetically pleasing than others. Ultimately, whether a robot is considered cute or not is subjective and can vary from person to person.
```
Resetting session could also trigger the starting prompt. 

