### PR TITLE
Code Formattting Issue

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -20,10 +20,31 @@ async def send_message(message, user_message):
         response += await responses.handle_response(user_message)
         if len(response) > 1900:
             # Split the response into smaller chunks of no more than 1900 characters each(Discord limit is 2000 per chunk)
-            response_chunks = [response[i:i+1900]
+            if "```" in response:
+                # Split the response if the code block exists
+                parts = response.split("```")
+                # Send the first message
+                await message.followup.send(parts[0])
+                # Send the code block in a seperate message
+                code_block = parts[1].split("\n")
+                formatted_code_block = ""
+                for line in code_block:
+                    while len(line) > 50:
+                    # Split the line at the 50th character
+                        formatted_code_block += line[:50] + "\n"
+                        line = line[50:]
+                    formatted_code_block += line + "\n" # Add the line and seperate with new line
+
+                # Send the code block in a separate message
+                await message.followup.send("```" + formatted_code_block + "```") 
+
+                # Send the remaining of the response in another message
+                await message.followup.send(parts[2])
+            else:
+                response_chunks = [response[i:i+1900]
                                for i in range(0, len(response), 1900)]
-            for chunk in response_chunks:
-                await message.followup.send(chunk)
+                for chunk in response_chunks:
+                    await message.followup.send(chunk)
         else:
             await message.followup.send(response)
     except Exception as e:


### PR DESCRIPTION
Fixed a code formatting from issue #34 https://github.com/Zero6992/chatGPT-discord-bot/issues/34

The purposed changes will now check if the discord identifier for code blocks "```" is present, if so handle it accordingly by separating the first message and send the code block in a separate message to ensure that the start and end of the code will appear to be nested within the code block.