### PR TITLE
Enable /reset 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 discord.py==2.1.0
 python-dotenv==0.21.1
-revChatGPT==3.0.5
+revChatGPT==3.0.9

--- a/src/bot.py
+++ b/src/bot.py
@@ -210,9 +210,14 @@ def run_discord_bot():
             await interaction.followup.send(
                 "> **Info: You are now in Website ChatGPT model.**\n> You need to set your `SESSION_TOKEN` or `OPENAI_EMAIL` and `OPENAI_PASSWORD` in `env` file.")
             logger.warning("\x1b[31mSwitch to UNOFFICIAL(Website) chat model\x1b[0m")
+            
     @client.tree.command(name="reset", description="Complete reset ChatGPT conversation history")
     async def reset(interaction: discord.Interaction):
-        responses.chatbot.reset_chat()
+        chat_model = os.getenv("CHAT_MODEL")
+        if chat_model == "OFFICIAL":
+            responses.offical_chatbot.reset()
+        elif chat_model == "UNOFFICIAL":
+            responses.unofficial_chatbot.clear_conversations()
         await interaction.response.defer(ephemeral=False)
         await interaction.followup.send("> **Info: I have forgotten everything.**")
         logger.warning(

--- a/src/bot.py
+++ b/src/bot.py
@@ -217,7 +217,7 @@ def run_discord_bot():
         if chat_model == "OFFICIAL":
             responses.offical_chatbot.reset()
         elif chat_model == "UNOFFICIAL":
-            responses.unofficial_chatbot.clear_conversations()
+            responses.unofficial_chatbot.reset_chat()
         await interaction.response.defer(ephemeral=False)
         await interaction.followup.send("> **Info: I have forgotten everything.**")
         logger.warning(


### PR DESCRIPTION
As pointed out in #219 , /reset is not available.
The new version 3.0.9 of revChatGPT, the module we are using, had a command implemented to reset the conversation.
So I updated revChatGPT and enabled the command.

I have tested it in OFFICIAL but not in UNOFFICIAL, but I hope this PR will be helpful.